### PR TITLE
Add lorem ipsum paragraph to About page

### DIFF
--- a/data/page--about.json
+++ b/data/page--about.json
@@ -3,7 +3,7 @@
   "title": "About",
   "slug": "about",
   "date": "2023-11-05T00:14:32",
-  "dateModified": "2025-08-24T00:22:18",
+  "dateModified": "2026-08-11T00:00:00",
   "hero": {
     "title": "Hi, I'm Graciela Alaniz",
     "type": "profile",
@@ -86,6 +86,11 @@
           "title": "Get in touch",
           "size": "l",
           "internalLink": "page--contact"
+        },
+        {
+          "renderType": "richText",
+          "tag": "p",
+          "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Adds a lorem ipsum paragraph to the bottom of the About page content, after the "Get in touch" button
- Updates `dateModified` on the About page

## Test plan
- [x] Validated `data/page--about.json` as valid JSON

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8AL85PQtiVzXcRZzPM8bx)_