### PR TITLE
fix: let the worker reach the access certs endpoint

### DIFF
--- a/.github/workflows/cf-preview.yml
+++ b/.github/workflows/cf-preview.yml
@@ -83,11 +83,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Install PNPM
-      - name: Install PNPM
-        uses: pnpm/action-setup@v5
-
-      # Set up Node.js for PNPM
+      # Set up Node.js. No pnpm and no checkout — this job runs one command,
+      # and pnpm/action-setup reads its version from a package.json that a job
+      # without a checkout does not have
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
@@ -96,7 +94,7 @@ jobs:
       # Remove the worker this pull request was previewed on
       - name: Delete preview
         run: |
-          pnpm dlx wrangler@4 delete \
+          npx --yes wrangler@4 delete \
             --name alaniz-creative-pr-${{ github.event.pull_request.number }} \
             --force || true
         env:

--- a/src/workers/Content/ContentAccess.ts
+++ b/src/workers/Content/ContentAccess.ts
@@ -25,6 +25,11 @@ interface ContentAccessKeys {
 /**
  * Fetch the Access signing keys, from cache where possible.
  *
+ * This endpoint is public, but a worker subrequest to a Cloudflare proxied
+ * hostname can be routed internally rather than out to the public internet,
+ * where it answers 403. The `global_fetch_strictly_public` compatibility flag
+ * in `wrangler.json` is what stops that, and removing it breaks this.
+ *
  * @param {ContentEnv} env
  * @return {Promise<ContentAccessKeys>}
  */

--- a/src/workers/Content/ContentMedia.ts
+++ b/src/workers/Content/ContentMedia.ts
@@ -147,6 +147,43 @@ const getMediaPage = (env: ContentEnv, images: ContentImage[], message?: string)
 }
 
 /**
+ * Render a failure as a page.
+ *
+ * Deliberately renders nothing but the message — whatever went wrong may be
+ * the very thing the library needs to list itself, so this must not go back
+ * to the network to say so.
+ *
+ * @param {unknown} error
+ * @return {Response}
+ */
+const getMediaError = (error: unknown): Response => {
+  const message = error instanceof Error ? error.message : 'Something went wrong.'
+  const body = /* html */`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Media library</title>
+  <style>${mediaStyles}</style>
+</head>
+<body>
+  <h1>Media library</h1>
+  <div role="alert">${escape(message)}</div>
+  <p><a href="/media">Try again</a></p>
+</body>
+</html>`
+
+  return new Response(body, {
+    status: 500,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store'
+    }
+  })
+}
+
+/**
  * Read a text field from a submitted form.
  *
  * @param {FormData} form
@@ -172,25 +209,25 @@ const getFormText = (form: FormData, name: string): string => {
  * @return {Promise<Response>}
  */
 const handleMedia = async (request: Request, env: ContentEnv): Promise<Response> => {
-  const identity = await getAccessIdentity(request, env)
-
-  if (!identity) {
-    return new Response('Not authorised', { status: 403 })
-  }
-
   const { pathname } = new URL(request.url)
 
-  if (request.method === 'GET' && pathname === '/media') {
-    return await renderMedia(env)
-  }
-
-  if (request.method !== 'POST') {
-    return new Response('Not found', { status: 404 })
-  }
-
-  const form = await request.formData()
-
   try {
+    const identity = await getAccessIdentity(request, env)
+
+    if (!identity) {
+      return new Response('Not authorised', { status: 403 })
+    }
+
+    if (request.method === 'GET' && pathname === '/media') {
+      return await renderMedia(env)
+    }
+
+    if (request.method !== 'POST') {
+      return new Response('Not found', { status: 404 })
+    }
+
+    const form = await request.formData()
+
     if (pathname === '/media/upload') {
       const file = form.get('file')
 
@@ -215,11 +252,16 @@ const handleMedia = async (request: Request, env: ContentEnv): Promise<Response>
 
       return await renderMedia(env, `Deleted ${key}.`)
     }
-  } catch (error) {
-    return await renderMedia(env, error instanceof Error ? error.message : 'Something went wrong.')
-  }
 
-  return new Response('Not found', { status: 404 })
+    return new Response('Not found', { status: 404 })
+  } catch (error) {
+    /* Anything that gets here — a missing secret, GitHub refusing, a bad
+       upload — is rendered rather than thrown. A thrown error reaches the
+       browser as a worker exception with a ray id and nothing else, which
+       tells the person reading it nothing they can act on */
+
+    return getMediaError(error)
+  }
 }
 
 /**

--- a/src/workers/Content/ContentWorker.ts
+++ b/src/workers/Content/ContentWorker.ts
@@ -51,15 +51,26 @@ const contentHandler = {
   async fetch (request: Request, env: ContentEnv): Promise<Response> {
     const { pathname } = new URL(request.url)
 
-    if (pathname === '/authorize') {
-      return await handleAuthorize(request, env)
-    }
+    try {
+      if (pathname === '/authorize') {
+        return await handleAuthorize(request, env)
+      }
 
-    if (pathname === '/media' || pathname.startsWith('/media/')) {
-      return await handleMedia(request, env)
-    }
+      if (pathname === '/media' || pathname.startsWith('/media/')) {
+        return await handleMedia(request, env)
+      }
 
-    return new Response('Not found', { status: 404 })
+      return new Response('Not found', { status: 404 })
+    } catch (error) {
+      /* A thrown error reaches the browser as a worker exception carrying a
+         ray id and nothing else. Saying what happened costs one line and
+         saves reading logs to find out */
+
+      return new Response(error instanceof Error ? error.message : 'Something went wrong', {
+        status: 500,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+      })
+    }
   }
 }
 

--- a/src/workers/Content/wrangler.json
+++ b/src/workers/Content/wrangler.json
@@ -3,9 +3,6 @@
   "main": "./ContentWorker.ts",
   "compatibility_date": "2025-10-14",
   "compatibility_flags": [
-    // Without this, a subrequest to a Cloudflare proxied hostname can be
-    // routed internally instead of going out to the public internet, and the
-    // Access certs endpoint answers 403. It is public — curl gets a 200.
     "global_fetch_strictly_public"
   ],
   "workers_dev": false,

--- a/src/workers/Content/wrangler.json
+++ b/src/workers/Content/wrangler.json
@@ -2,6 +2,12 @@
   "name": "alaniz-creative-content",
   "main": "./ContentWorker.ts",
   "compatibility_date": "2025-10-14",
+  "compatibility_flags": [
+    // Without this, a subrequest to a Cloudflare proxied hostname can be
+    // routed internally instead of going out to the public internet, and the
+    // Access certs endpoint answers 403. It is public — curl gets a 200.
+    "global_fetch_strictly_public"
+  ],
   "workers_dev": false,
   "preview_urls": false,
   "keep_vars": true,


### PR DESCRIPTION
`/media` threw because the Access JWKS fetch answered 403. The endpoint is public — curl gets a 200 — but subrequests to a Cloudflare proxied hostname can be routed internally instead of out to the public internet, so `global_fetch_strictly_public` forces the latter.

Also renders errors instead of throwing them, so a failure says what broke rather than surfacing as error 1101 with a ray id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)